### PR TITLE
Errors and enhancements

### DIFF
--- a/backend/src/interfaces/user.interface.ts
+++ b/backend/src/interfaces/user.interface.ts
@@ -3,4 +3,5 @@ export interface User {
   name: string;
   email: string;
   password: string;
+  isManagement: boolean;
 }

--- a/backend/src/routes/login.route.ts
+++ b/backend/src/routes/login.route.ts
@@ -9,6 +9,9 @@ export class LoginRoute {
   public users = userModel;
   private privateKey = process.env.PRIVATE_KEY;
 
+  //I don't know if this can or should be managed from here?
+  private isManagementLogin = false; 
+
   constructor() {
     this.initializeRoutes();
   }
@@ -23,6 +26,7 @@ export class LoginRoute {
 
       const password = await bcrypt.compare(req.body.password, user.password);
       if (!password) return res.status(404).send("Incorrect password");
+      if (this.isManagementLogin && !user.isManagement) return res.status(404).send("Insufficient permission to access management app")
 
       const token = jwt.sign({ user }, this.privateKey);
 

--- a/client/src/app/login/login.component.html
+++ b/client/src/app/login/login.component.html
@@ -20,6 +20,7 @@
       <mat-form-field appearance="fill">
         <mat-label>Password</mat-label>
         <input
+          type="password"
           matInput
           placeholder="Password"
           [(ngModel)]="userLogin.password"
@@ -30,6 +31,11 @@
     <div class="centered">
       <button mat-button>Cancel</button>
       <button mat-button (click)="login()">Login</button>
+    </div>
+    <div class="centered">
+      <p style="color: red">
+        {{ errorText }}
+      </p>
     </div>
   </div>
 </div>

--- a/client/src/app/login/login.component.ts
+++ b/client/src/app/login/login.component.ts
@@ -9,6 +9,7 @@ import { RoutingService } from '../services/routing.service';
 })
 export class LoginComponent implements OnInit {
   isManagementLogin: boolean = false;
+  errorText: String = "";
   public userLogin: Login = { email: '', password: '' };
 
   constructor(
@@ -21,20 +22,26 @@ export class LoginComponent implements OnInit {
   }
 
   login() {
+    this.errorText = ""
+
     if (this.isManagementLogin)
       this.loginService.login(this.userLogin).subscribe({
         next: (result) => {
           this.storeToken(result.token);
           this.routingService.navigateToHome();
         },
-        error: () => alert("Unfortunately we could not find your account")
+        error: (e) => {
+          this.errorText = e.error;
+        }
       });
     else
       this.loginService.login(this.userLogin).subscribe({
         next: (result) => {
           this.routingService.navigateToRedirectPage(result.token);
         },
-        error: () => alert("Unfortunately we could not find your account")
+        error: (e) => {
+          this.errorText = e.error;
+        }
       });
   }
 

--- a/client/src/app/route-guards/management.guard.ts
+++ b/client/src/app/route-guards/management.guard.ts
@@ -29,7 +29,6 @@ export class ManagementGuard implements CanActivate {
     if (!isManagement) {
       localStorage.clear()
       this.routingService.navigateToLogin();
-      window.alert("You do not have management access")
     }
     return isManagement;
   }


### PR DESCRIPTION
Errors for user/password shown to user.
IsManagement error can be enabled through changing boolean isManagementLogin in login.route.ts but currently applies across both public and management apps as they share this route